### PR TITLE
Openemu ColecoVision and Intellivision Game Problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # Openemu
 ColecoVision and Intellivision not properly working
+Select a game in ColecoVision and it opens into an black screen
+
+md5 hashtag -
+
+tony-powells-mac-pro-2:~ tonypowell$ md5 /Users/tonypowell/Documents/Full_Rom_Sets/Colecovision\ \(GoodCol\ v2.01\)/ColecoVision\ BIOS\ \(1982\).col 
+MD5 (/Users/tonypowell/Documents/Full_Rom_Sets/Colecovision (GoodCol v2.01)/ColecoVision BIOS (1982).col) = 2c66f5911e5b42b8ebe113403548eee7
+
+Console info -
+
+Jul 16 23:02:29 tony-powells-mac-pro-2 OpenEmu[1260]: Macally ICEKEY2 Keyboard
+Jul 16 23:02:29 tony-powells-mac-pro-2 OpenEmu[1260]: OELibraryDatabase loadFromURL: 'file:///Users/tonypowell/Library/Application%20Support/OpenEmu/Game%20Library/'
+Jul 16 23:02:29 tony-powells-mac-pro-2 OpenEmu[1260]: window did load
+Jul 16 23:02:46 tony-powells-mac-pro-2 OpenEmuHelperApp[1265]: parent application is: OpenEmu
+Jul 16 23:02:46 tony-powells-mac-pro-2 OpenEmuHelperApp[1265]: Macally ICEKEY2 Keyboard
+Jul 16 23:02:46 tony-powells-mac-pro-2 OpenEmu[1260]: SETUP DONE.
+Jul 16 23:02:46 tony-powells-mac-pro-2 OpenEmu[1260]: Display's nominal refresh rate is 59.95 Hz
+Jul 16 23:02:47 tony-powells-mac-pro-2 OpenEmuHelperApp[1265]: Rate change 0.000000 -> 1.000000
+ 
+
+Select a game in Intellivision and I get a ROM did not load error
+
+md5 hashtag -
+
+MD5 (/Users/tonypowell/Downloads/Executive ROM, The (1978) (Mattel).int) = 62e761035cb657903761800f4437b8af
+tony-powells-mac-pro-2:~ tonypowell$ md5 /Users/tonypowell/Downloads/GROM\,\ The\ \(1978\)\ \(General\ Instruments\)\ \[\!\].int 
+MD5 (/Users/tonypowell/Downloads/GROM, The (1978) (General Instruments) [!].int) = 0cd5946c6473e42e8e4c2137785e427f
+tony-powells-mac-pro-2:~ tonypowell$ md5 /Users/tonypowell/Downloads/IntelliVoice\ BIOS\ \(1981\)\ \(Mattel\).int 
+MD5 (/Users/tonypowell/Downloads/IntelliVoice BIOS (1981) (Mattel).int) = d5530f74681ec6e0f282dab42e6b1c5f
+tony-powells-mac-pro-2:~ tonypowell$ md5/Users/tonypowell/Downloads/Entertainment\ Computer\ System\ EXEC-BASIC\ \(1978\)\ \(Mattel\).7z 
+-bash: md5/Users/tonypowell/Downloads/Entertainment Computer System EXEC-BASIC (1978) (Mattel).7z: No such file or directory
+tony-powells-mac-pro-2:~ tonypowell$ md5 /Users/tonypowell/Documents/Full_Rom_Sets/Intellivision/Mattel\ Intellivision\ \(GoodINTV\ v2.03\)/Entertainment\ Computer\ System\ EXEC-BASIC\ \(1978\)\ \(Mattel\)\ \[\!\].int 
+MD5 (/Users/tonypowell/Documents/Full_Rom_Sets/Intellivision/Mattel Intellivision (GoodINTV v2.03)/Entertainment Computer System EXEC-BASIC (1978) (Mattel) [!].int) = 2e72a9a2b897d330a35c8b07a6146c52
+
+
+Console info -
+
+Jul 16 23:15:19 tony-powells-mac-pro-2 OpenEmu[1326]: Macally ICEKEY2 Keyboard
+Jul 16 23:15:19 tony-powells-mac-pro-2 OpenEmu[1326]: OELibraryDatabase loadFromURL: 'file:///Users/tonypowell/Library/Application%20Support/OpenEmu/Game%20Library/'
+Jul 16 23:15:19 tony-powells-mac-pro-2 OpenEmu[1326]: window did load
+Jul 16 23:15:33 tony-powells-mac-pro-2 OpenEmuHelperApp[1330]: parent application is: OpenEmu
+Jul 16 23:15:33 tony-powells-mac-pro-2 OpenEmuHelperApp[1330]: Macally ICEKEY2 Keyboard
+Jul 16 23:15:33 tony-powells-mac-pro-2 OpenEmuHelperApp[1330]: ROM did not load.
+ 


### PR DESCRIPTION
md5 and console Information for two gaming library problems.  ColecoVision shows a black screen; Intellivision gives a ROM did not load message.